### PR TITLE
Update 01-design-duration-terms.adoc

### DIFF
--- a/docs/02-design/01-design-duration-terms.adoc
+++ b/docs/02-design/01-design-duration-terms.adoc
@@ -14,7 +14,7 @@ include::../config/_feedback.adoc[]
 
 === Wesentliche Begriffe
 
-Entwurf; Vorgehen beim Entwurf; Entwurfsentscheidung; Sichten; Schnittstellen; technische und querschnittliche Konzepte; Stereotypen; Architekturmuster; Entwurfsmuster; Mustersprachen; Entwurfsprinzipien; Abhängigkeit; Kopplung; Kohäsion; fachliche und technische Architekturen; Top-down- und Bottom-Up-Vorgehen; modellbasierter Entwurf; iterativer/inkrementeller Entwurf; Domain-Driven Design
+Entwurf; Vorgehen beim Entwurf; Entwurfsentscheidung; Sichten; Schnittstellen; technische Konzepte und Querschnittskonzepte; Stereotypen; Architekturmuster; Entwurfsmuster; Mustersprachen; Entwurfsprinzipien; Abhängigkeit; Kopplung; Kohäsion; fachliche und technische Architekturen; Top-down- und Bottom-Up-Vorgehen; modellbasierter Entwurf; iterativer/inkrementeller Entwurf; Domain-Driven Design
 
 // end::DE[]
 


### PR DESCRIPTION
Begriff an Kapitel 2 angepasst: Querschnittskonzepte anstelle von "querschnittliche Konzepte"